### PR TITLE
Fix compile on yocto 5.0

### DIFF
--- a/src/ob_camera_node.cpp
+++ b/src/ob_camera_node.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  *******************************************************************************/
 
+#include <fstream>
 #include "orbbec_camera/ob_camera_node.h"
 #include "libobsensor/hpp/Utils.hpp"
 #if defined(USE_RK_HW_DECODER)


### PR DESCRIPTION
Needed to include <fstream> for std::ofstream.  This must have come in through other include files in yocto-4.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/OrbbecSDK_ROS1/3)
<!-- Reviewable:end -->
