### PR TITLE
Change timestamp to system time

### DIFF
--- a/src/ob_camera_node.cpp
+++ b/src/ob_camera_node.cpp
@@ -288,7 +288,7 @@ void OBCameraNode::getParameters() {
   enable_ldp_ = nh_private_.param<bool>("enable_ldp", true);
   tf_publish_rate_ = nh_private_.param<double>("tf_publish_rate", 0.0);
   enable_heartbeat_ = nh_private_.param<bool>("enable_heartbeat", false);
-  time_domain_ = nh_private_.param<std::string>("time_domain", "global");
+  time_domain_ = nh_private_.param<std::string>("time_domain", "system");
   exposure_range_mode_ = nh_private_.param<std::string>("exposure_range_mode", "default");
   disparity_range_mode_ = nh_private_.param<int>("disparity_range_mode", -1);
   disparity_search_offset_ = nh_private_.param<int>("disparity_search_offset", -1);


### PR DESCRIPTION
Change the default time to stamp the pointclouds with to the system's time instead of the 'global' time, which is derived from the device time.
This was causing safety-velocity to intermittently expire pointclouds and prevent motion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/OrbbecSDK_ROS1/4)
<!-- Reviewable:end -->
