### PR TITLE
Abort list_devices if systemd services are running

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,9 @@ find_package(Boost REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost COMPONENTS filesystem system REQUIRED)
+
+pkg_check_modules(LIBSYSTEMD REQUIRED libsystemd)
+
 # check if boost was found
 if(Boost_FOUND)
     message(STATUS "Boost found!")
@@ -147,6 +150,7 @@ set(COMMON_INCLUDE_DIRS
   ${Boost_INCLUDE_DIRS}
   ${OpenCV_INCLUDED_DIRS}
   ${ORBBEC_INCLUDE_DIR}
+  ${LIBSYSTEMD_INCLUDE_DIRS}
 )
 if (USE_NV_HW_DECODER)
   list(APPEND COMMON_INCLUDE_DIRS
@@ -210,6 +214,7 @@ set(COMMON_LINK_LIBRARIES
   Threads::Threads
   -lrt
   -ldw # for stack trace
+  ${LIBSYSTEMD_LIBRARIES}
 )
 
 if (USE_RK_HW_DECODER)

--- a/src/list_devices_node.cpp
+++ b/src/list_devices_node.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <regex>
 #include <thread>
+#include <systemd/sd-bus.h>
 std::string parseUsbPort(const std::string &line) {
   std::string port_id;
   std::regex self_regex("(?:[^ ]+/usb[0-9]+[0-9./-]*/){0,1}([0-9.-]+)(:){0,1}[^ ]*",
@@ -38,7 +39,75 @@ std::string parseUsbPort(const std::string &line) {
   }
   return port_id;
 }
+bool checkSystemdServices(){
+  // Badger: Check if any of the depthcam systemd services are running,
+  // return false and print the offending unit name(s).
+  bool success = true;
+  sd_bus *bus = nullptr;
+
+  int ret = sd_bus_default_system(&bus);
+  if (ret < 0) {
+    ROS_ERROR_STREAM("Cannot verify state of systemd services");
+    success = false;
+  }
+  else {
+    const char* unit_path = nullptr;
+    sd_bus_message* reply = nullptr;
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+    int r;
+
+    // List all units
+    r = sd_bus_call_method(
+      bus,
+      "org.freedesktop.systemd1",
+      "/org/freedesktop/systemd1",
+      "org.freedesktop.systemd1.Manager",
+      "ListUnits",
+      NULL,
+      &reply,
+      NULL
+    );
+
+    if (r < 0) {
+      ROS_ERROR_STREAM("Failed to ListUnits");
+      success = false;
+    }
+
+    r = sd_bus_message_enter_container(reply, 'a', "(ssssssouso)");
+    if (r < 0) {
+      ROS_ERROR_STREAM("Failed to enter array of structs");
+      success = false;
+    }
+
+    // Itterate through all units, look for depthcam units.
+    // If a depthcam unit is active, flip boolean and log error for it.
+    while (sd_bus_message_enter_container(reply, 'r', "ssssssouso") > 0) {
+      const char *unit_name, *active_state;
+      r = sd_bus_message_read(reply, "ssss", &unit_name, NULL, NULL, &active_state);
+      if (r < 0) {
+        ROS_ERROR_STREAM("Failed to parse unit struct: " << strerror(-r));
+        success = false;
+      }
+      else if (strncmp(unit_name, "ros.depthcam", strlen("ros.depthcam")) == 0) {
+        if (strcmp(active_state, "active") == 0) {
+          ROS_ERROR_STREAM("Unit is active: " << unit_name);
+          success = false;
+        }
+      }
+      sd_bus_message_skip(reply, "ssouso");
+      sd_bus_message_exit_container(reply);
+    }
+    sd_bus_message_exit_container(reply);
+    sd_bus_message_unref(reply);
+  }
+  sd_bus_unref(bus);
+  return success;
+}
 int main() {
+  if (!checkSystemdServices()) {
+    ROS_ERROR_STREAM("Aborting; Please stop all depthcam systemd services.");
+    return 0;
+  }
   auto context = std::make_shared<ob::Context>();
   context->setLoggerSeverity(OBLogSeverity::OB_LOG_SEVERITY_OFF);
   auto list = context->queryDeviceList();


### PR DESCRIPTION
Previously, attempting to run the list_devices_node to get all connected Orbbec cameras while the systemd services were running was impossible. After switching to v4l as the UVC backed this is no longer true. Running the list_devices node while the systemd services are running though breaks the v4l2 udev port and requires the truck to be rebooted.

Check all units for ones that start with ros.depthcam, and do not attempt to query the devices if any are active.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/OrbbecSDK_ROS1/6)
<!-- Reviewable:end -->
