### PR TITLE
Periodically publish LDP state and distance

### DIFF
--- a/include/orbbec_camera/ob_camera_node.h
+++ b/include/orbbec_camera/ob_camera_node.h
@@ -453,6 +453,8 @@ class OBCameraNode {
   std::shared_ptr<ob::Config> pipeline_config_ = nullptr;
   ros::Publisher depth_cloud_pub_;
   ros::Publisher depth_registered_cloud_pub_;
+  ros::Publisher ldp_status_pub_;
+  ros::Timer periodic_ldp_timer_;
   sensor_msgs::PointCloud2 cloud_msg_;
   std::recursive_mutex cloud_mutex_;
   std::atomic_bool pipeline_started_{false};

--- a/src/ros_setup.cpp
+++ b/src/ros_setup.cpp
@@ -16,6 +16,7 @@
 
 #include "orbbec_camera/ob_camera_node.h"
 #include "orbbec_camera/utils.h"
+#include <std_msgs/Int16.h>
 #include <std_msgs/String.h>
 
 namespace orbbec_camera {
@@ -687,6 +688,18 @@ void OBCameraNode::setupDevices() {
       } else {
         ROS_ERROR_STREAM("exposure range mode does not support this setting");
       }
+    }
+    if (device_->isPropertySupported(OB_PROP_LDP_MEASURE_DISTANCE_INT, OB_PERMISSION_READ)) {
+      ldp_status_pub_ = nh_.advertise<std_msgs::Int16>("/" + camera_name_ + "/ldp_status", 1);
+      periodic_ldp_timer_ = nh_.createTimer(ros::Duration(0.1), [this](const ros::TimerEvent&) {
+        try {
+          std_msgs::Int16 ret;
+          ret.data = device_->getIntProperty(OB_PROP_LDP_MEASURE_DISTANCE_INT);
+          ldp_status_pub_.publish(ret);
+        } catch (const ob::Error& e) {
+          ROS_ERROR_THROTTLE(1, ("Failed to acquire LDP information: %s", e.getMessage()));
+        }
+      });
     }
   } catch (const ob::Error& e) {
     ROS_ERROR_STREAM("Failed to setup devices: " << e.getMessage());


### PR DESCRIPTION
The LDP is a safety sensor on the Gemini 2 that watches for close objects and disables the laser emitter if something is too close. This provides us a cheap and scene independent method of determining when the low depthcam on a Wombat is obstructed.

Publish the LDP state (if something is detected close) and the measured distance at a rate of 10hz.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/OrbbecSDK_ROS1/8)
<!-- Reviewable:end -->
