### PR TITLE
Set depth-work-mode first

### DIFF
--- a/src/ros_setup.cpp
+++ b/src/ros_setup.cpp
@@ -326,6 +326,10 @@ void OBCameraNode::setupDevices() {
       device_->setBoolProperty(OB_PROP_DEVICE_USB3_REPEAT_IDENTIFY_BOOL,
                                retry_on_usb3_detection_failure_);
     }
+    if (!depth_work_mode_.empty()) {
+      ROS_INFO_STREAM("Set depth work mode: " << depth_work_mode_);
+      device_->switchDepthWorkMode(depth_work_mode_.c_str());
+    }
     if (device_->isPropertySupported(OB_PROP_DEPTH_MAX_DIFF_INT, OB_PERMISSION_WRITE)) {
       auto default_noise_removal_filter_min_diff =
           device_->getIntProperty(OB_PROP_DEPTH_MAX_DIFF_INT);
@@ -357,10 +361,6 @@ void OBCameraNode::setupDevices() {
     if (device_->isPropertySupported(OB_PROP_DEPTH_SOFT_FILTER_BOOL, OB_PERMISSION_READ_WRITE)) {
       device_->setBoolProperty(OB_PROP_DEPTH_SOFT_FILTER_BOOL, enable_noise_removal_filter_);
       ROS_INFO_STREAM("enable_noise_removal_filter:" << enable_noise_removal_filter_);
-    }
-    if (!depth_work_mode_.empty()) {
-      ROS_INFO_STREAM("Set depth work mode: " << depth_work_mode_);
-      device_->switchDepthWorkMode(depth_work_mode_.c_str());
     }
     if (laser_energy_level_ != -1 &&
         device_->isPropertySupported(OB_PROP_LASER_ENERGY_LEVEL_INT, OB_PERMISSION_READ_WRITE)) {


### PR DESCRIPTION
I did not realize previously, but whenever the work mode changes on the device, the lower camera driver resets the camera which blows away any settings previously applied. This was happening on boot and whenever the power to the port was pulled (as the mode we use is not the default mode).

The noise removal filter settings were the only settings applied before this, and were getting set back to the default values. These default values are too permissive and allow for small impulse noise that can cause stuttering movement.

As an easy fix, set the work mode first.

ROS-2351: Depthcamera NoiseRemovalFilter settings not always applying correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/OrbbecSDK_ROS1/9)
<!-- Reviewable:end -->
